### PR TITLE
feat(users): add volsync backups for hermes-agent instances

### DIFF
--- a/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-crowlex-data.yaml
+++ b/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-crowlex-data.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: MinioUser
+metadata:
+  name: volsync-kube-lab-hermes-agent-crowlex-data
+  namespace: nas.techtales.io
+spec:
+  description: volsync kube-lab backup account for hermes-agent-crowlex
+  disabled: false
+  permissions:
+    - bucket: volsync
+      path: /*
+      actions:
+        - ListBucket
+    - bucket: volsync
+      path: /kube-lab/hermes-agent/hermes-agent-crowlex-data/*
+      actions:
+        - GetObject
+        - PutObject
+        - DeleteObject

--- a/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-jazzlyn-data.yaml
+++ b/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-jazzlyn-data.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: MinioUser
+metadata:
+  name: volsync-kube-lab-hermes-agent-jazzlyn-data
+  namespace: nas.techtales.io
+spec:
+  description: volsync kube-lab backup account for hermes-agent-jazzlyn
+  disabled: false
+  permissions:
+    - bucket: volsync
+      path: /*
+      actions:
+        - ListBucket
+    - bucket: volsync
+      path: /kube-lab/hermes-agent/hermes-agent-jazzlyn-data/*
+      actions:
+        - GetObject
+        - PutObject
+        - DeleteObject

--- a/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-techinik-data.yaml
+++ b/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-techinik-data.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: MinioUser
+metadata:
+  name: volsync-kube-lab-hermes-agent-techinik-data
+  namespace: nas.techtales.io
+spec:
+  description: volsync kube-lab backup account for hermes-agent-techinik
+  disabled: false
+  permissions:
+    - bucket: volsync
+      path: /*
+      actions:
+        - ListBucket
+    - bucket: volsync
+      path: /kube-lab/hermes-agent/hermes-agent-techinik-data/*
+      actions:
+        - GetObject
+        - PutObject
+        - DeleteObject

--- a/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-tyriis-data.yaml
+++ b/data/users/nas.techtales.io/volsync-kube-lab-hermes-agent-tyriis-data.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: terraform.techtales.io/v1alpha1
+kind: MinioUser
+metadata:
+  name: volsync-kube-lab-hermes-agent-tyriis-data
+  namespace: nas.techtales.io
+spec:
+  description: volsync kube-lab backup account for hermes-agent-tyriis
+  disabled: false
+  permissions:
+    - bucket: volsync
+      path: /*
+      actions:
+        - ListBucket
+    - bucket: volsync
+      path: /kube-lab/hermes-agent/hermes-agent-tyriis-data/*
+      actions:
+        - GetObject
+        - PutObject
+        - DeleteObject


### PR DESCRIPTION
Creates S3 credentials and strict path restrictions for the 4 hermes-agent instances to use VolSync backups to MinIO.

tyriis/home-ops#8831