### PR TITLE
Standardize terraform-docs config

### DIFF
--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,12 +1,5 @@
 ---
 formatter: markdown
-header-from: main.tf
-
-sections:
-  hide-all: false
-  hide: []
-  show-all: true
-  show: []
 
 output:
   file: "README.md"
@@ -15,22 +8,10 @@ output:
     <!-- BEGIN_TF_DOCS -->
     {{ .Content }}
     <!-- END_TF_DOCS -->
-  check: false
-
-output-values:
-  enabled: false
-  from: ""
 
 sort:
   enabled: true
   by: required
 
 settings:
-  anchor: true
-  color: true
-  default: true
-  escape: true
   indent: 2
-  required: true
-  sensitive: true
-  type: true

--- a/modules/data/yaml-loader/README.md
+++ b/modules/data/yaml-loader/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.8 |
 
 ## Providers
 

--- a/modules/minio/bucket/README.md
+++ b/modules/minio/bucket/README.md
@@ -10,14 +10,14 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.7 |
-| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.8 |
+| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.3 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.1 |
+| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.3 |
 
 ## Modules
 
@@ -27,7 +27,7 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [minio_s3_bucket.main](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/resources/s3_bucket) | resource |
+| [minio_s3_bucket.main](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/resources/s3_bucket) | resource |
 
 ## Inputs
 

--- a/modules/minio/policy/README.md
+++ b/modules/minio/policy/README.md
@@ -10,14 +10,14 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.7 |
-| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.8 |
+| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.3 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.1 |
+| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.3 |
 
 ## Modules
 
@@ -27,9 +27,9 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [minio_iam_policy.main](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/resources/iam_policy) | resource |
-| [minio_iam_user_policy_attachment.main](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/resources/iam_user_policy_attachment) | resource |
-| [minio_iam_policy_document.main](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/data-sources/iam_policy_document) | data source |
+| [minio_iam_policy.main](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/resources/iam_policy) | resource |
+| [minio_iam_user_policy_attachment.main](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/resources/iam_user_policy_attachment) | resource |
+| [minio_iam_policy_document.main](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/modules/minio/user/README.md
+++ b/modules/minio/user/README.md
@@ -10,15 +10,15 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.7 |
-| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0, <= 1.15.8 |
+| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.3 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.10.1 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.1 |
+| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.3 |
 | <a name="provider_vault"></a> [vault](#provider\_vault) | 5.10.1 |
 
 ## Modules
@@ -29,7 +29,7 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [minio_iam_user.main](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/resources/iam_user) | resource |
+| [minio_iam_user.main](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/resources/iam_user) | resource |
 | [vault_generic_secret.minio_secret](https://registry.terraform.io/providers/hashicorp/vault/5.10.1/docs/resources/generic_secret) | resource |
 
 ## Inputs

--- a/terraform/nas.techtales.io/README.md
+++ b/terraform/nas.techtales.io/README.md
@@ -10,15 +10,15 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.7 |
-| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.8 |
+| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.3 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.10.1 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.1 |
+| <a name="provider_minio"></a> [minio](#provider\_minio) | 3.38.3 |
 | <a name="provider_vault"></a> [vault](#provider\_vault) | 5.10.1 |
 
 ## Modules
@@ -34,8 +34,8 @@
 
 | Name | Type |
 | ---- | ---- |
-| [minio_s3_bucket_replication.backup](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/resources/s3_bucket_replication) | resource |
-| [minio_s3_bucket_replication.terraform](https://registry.terraform.io/providers/aminueza/minio/3.38.1/docs/resources/s3_bucket_replication) | resource |
+| [minio_s3_bucket_replication.backup](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/resources/s3_bucket_replication) | resource |
+| [minio_s3_bucket_replication.terraform](https://registry.terraform.io/providers/aminueza/minio/3.38.3/docs/resources/s3_bucket_replication) | resource |
 | [vault_generic_secret.terraform_minio](https://registry.terraform.io/providers/hashicorp/vault/5.10.1/docs/data-sources/generic_secret) | data source |
 
 ## Inputs

--- a/terraform/synology.techtales.io/README.md
+++ b/terraform/synology.techtales.io/README.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.7 |
-| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0, <= 1.15.8 |
+| <a name="requirement_minio"></a> [minio](#requirement\_minio) | 3.38.3 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | 5.10.1 |
 
 ## Providers


### PR DESCRIPTION
- Standardize `.terraform-docs.yaml` to minimal format (terraform/ repos: indent 2)
- Regenerated READMEs via terraform-docs